### PR TITLE
update: fix linker flags ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: $(EXE)
 $(EXE): lex_yacc $(OBJ_DIR) $(BIN_DIR) $(OBJ_SUB) $(SRC)
 	gcc -g -o $(OBJ_DIR)/lex.yy.o -c $(OBJ_DIR)/lex.yy.c
 	gcc -g -o $(OBJ_DIR)/syntactic.tab.o -c $(OBJ_DIR)/syntactic.tab.c
-	gcc $(LDFLAGS) -g $(LDLIBS) -o $(EXE) $(OBJ)
+	gcc -g -o $(EXE) $(OBJ) $(LDFLAGS) $(LDLIBS)
 
 lex_yacc: $(OBJ_DIR)
 	bison -dv $(SRC_DIR)/syntactic.y


### PR DESCRIPTION
GCC post 4.5 requires linker flags such as `-l` to figure at the end of a link command.
Otherwise, GCC may not link as requested or not even compile correctly.